### PR TITLE
Update Appendix E - Add text description of the first 3 fill patterns

### DIFF
--- a/Function Reference/Appendix/pages/Appendix E - Miscellaneous Selectors.md
+++ b/Function Reference/Appendix/pages/Appendix E - Miscellaneous Selectors.md
@@ -54,6 +54,13 @@
 
 ![Fill Patterns List](images/Vs_fillpat.gif)
 
+The use of first 3 indexes may not be clear from the image.
+| Index | Patern |
+|-------|--------|
+|0|No Fill Pattern|
+|1|Solid Background Pattern|
+|2|Solid Foreground Pattern|
+
 ## Color Palette
 
 ![Color Palette List](images/Vs_pal256.gif)


### PR DESCRIPTION
From the graphic it's not clear that index 1 is the background and index 2 is the foreground. The foreground color is used for the solid pen color. This is important for the default preview/pre-draw during object insertion.