### PR TITLE
Update Python package catalog to v3.14.5

### DIFF
--- a/Marionette/pages/Python Package Catalog.md
+++ b/Marionette/pages/Python Package Catalog.md
@@ -24,6 +24,30 @@
 | shapely-2.1.2-cp314-cp314-win_amd64.whl | 2.1.2 | Windows | 2026/3.14.5 |
 | shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl | 2.1.2 | MacOS X M1 | 2026/3.14.5 |
 
+| numpy-1.22.1-cp39-cp39-win_amd64 | 1.22.1 | Windows | 2025/3.9.2 |
+| numpy-1.22.1-cp39-cp39-macosx_10_9_x86_64 | 1.22.1 | MacOS X X86_64 | 2025/3.9.2 |
+| numpy-1.22.1-cp39-cp39-macosx_11_0_arm64 | 1.22.1 | MacOS X M1 | 2025/3.9.2 |
+| scipy-1.8.0-cp39-cp39-win_amd64 | 1.8.0 | Windows | 2025/3.9.2 |
+| scipy-1.8.0-cp39-cp39-macosx_10_9_x86_64 | 1.8.0 | MacOS X X86_64 | 2025/3.9.2 |
+| scipy-1.8.0-cp39-cp39-macosx_12_0_arm64 | 1.8.0 | MacOS X M1 | 2025/3.9.2 |
+| geopy-2.2.0-py3-none-any | 2.2.0 | Windows | 2025/3.9.2 |
+| geopy-2.2.0-py3-none-any | 2.2.0 | MacOS X X86_64 | 2025/3.9.2 |
+| geopy-2.2.0-py3-none-any | 2.2.0 | MacOS X M1 | 2025/3.9.2 |
+| Pillow-9.0.0-cp39-cp39-win_amd64 | 9.0.0 | Windows | 2025/3.9.2 |
+| Pillow-9.0.0-cp39-cp39-macosx_10_10_x86_64 | 9.0.0 | MacOS X X86_64 | 2025/3.9.2 |
+| Pillow-9.0.0-cp39-cp39-macosx_11_0_arm64 | 9.0.0 | MacOS X M1 | 2025/3.9.2 |
+| plotly-5.5.0-py2.py3-none-any | 5.5.0 | Windows | 2025/3.9.2 |
+| plotly-5.5.0-py2.py3-none-any | 5.5.0 | MacOS X X86_64 | 2025/3.9.2 |
+| plotly-5.5.0-py2.py3-none-any | 5.5.0 | MacOS X M1 | 2025/3.9.2 |
+| pandas-1.4.1-cp39-cp39-win_amd64 | 1.4.1 | Windows | 2025/3.9.2 |
+| pandas-1.4.1-cp39-cp39-macosx_10_9_x86_64 | 1.4.1 | MacOS X X86_64 | 2025/3.9.2 |
+| pandas-1.4.1-cp39-cp39-macosx_11_0_arm64 | 1.4.1 | MacOS X M1 | 2025/3.9.2 |
+| matplotlib-3.5.1-cp39-cp39-win_amd64 | 3.5.1 | Windows | 2025/3.9.2 |
+| matplotlib-3.5.1-cp39-cp39-macosx_10_9_x86_64 | 3.5.1 | MacOS X X86_64 | 2025/3.9.2 |
+| matplotlib-3.5.1-cp39-cp39-macosx_11_0_arm64 | 3.5.1 | MacOS X M1 | 2025/3.9.2 |
+| shapely-2.0.4-cp39-cp39-win_amd64.whl | 2.0.4 | Windows | 2025/3.9.2 |
+| shapely-2.0.4-cp39-cp39-macosx_10_9_universal2.whl | 2.0.4 | MacOS X M1 | 2025/3.9.2 |
+
 ## Description of the Marionette Node changes
 ![NewSyntax](files/NewSyntax.png)
 

--- a/Marionette/pages/Python Package Catalog.md
+++ b/Marionette/pages/Python Package Catalog.md
@@ -1,28 +1,28 @@
 | Package | Package Version | Package OS | VW Version Python Version |
 |---------|-----------------|------------|---------------------------|
-| numpy-1.22.1-cp39-cp39-win_amd64 | 1.22.1 | Windows | 2025/3.9.2 |
-| numpy-1.22.1-cp39-cp39-macosx_10_9_x86_64 | 1.22.1 | MacOS X X86_64 | 2025/3.9.2 |
-| numpy-1.22.1-cp39-cp39-macosx_11_0_arm64 | 1.22.1 | MacOS X M1 | 2025/3.9.2 |
-| scipy-1.8.0-cp39-cp39-win_amd64 | 1.8.0 | Windows | 2025/3.9.2 |
-| scipy-1.8.0-cp39-cp39-macosx_10_9_x86_64 | 1.8.0 | MacOS X X86_64 | 2025/3.9.2 |
-| scipy-1.8.0-cp39-cp39-macosx_12_0_arm64 | 1.8.0 | MacOS X M1 | 2025/3.9.2 |
-| geopy-2.2.0-py3-none-any | 2.2.0 | Windows | 2025/3.9.2 |
-| geopy-2.2.0-py3-none-any | 2.2.0 | MacOS X X86_64 | 2025/3.9.2 |
-| geopy-2.2.0-py3-none-any | 2.2.0 | MacOS X M1 | 2025/3.9.2 |
-| Pillow-9.0.0-cp39-cp39-win_amd64 | 9.0.0 | Windows | 2025/3.9.2 |
-| Pillow-9.0.0-cp39-cp39-macosx_10_10_x86_64 | 9.0.0 | MacOS X X86_64 | 2025/3.9.2 |
-| Pillow-9.0.0-cp39-cp39-macosx_11_0_arm64 | 9.0.0 | MacOS X M1 | 2025/3.9.2 |
-| plotly-5.5.0-py2.py3-none-any | 5.5.0 | Windows | 2025/3.9.2 |
-| plotly-5.5.0-py2.py3-none-any | 5.5.0 | MacOS X X86_64 | 2025/3.9.2 |
-| plotly-5.5.0-py2.py3-none-any | 5.5.0 | MacOS X M1 | 2025/3.9.2 |
-| pandas-1.4.1-cp39-cp39-win_amd64 | 1.4.1 | Windows | 2025/3.9.2 |
-| pandas-1.4.1-cp39-cp39-macosx_10_9_x86_64 | 1.4.1 | MacOS X X86_64 | 2025/3.9.2 |
-| pandas-1.4.1-cp39-cp39-macosx_11_0_arm64 | 1.4.1 | MacOS X M1 | 2025/3.9.2 |
-| matplotlib-3.5.1-cp39-cp39-win_amd64 | 3.5.1 | Windows | 2025/3.9.2 |
-| matplotlib-3.5.1-cp39-cp39-macosx_10_9_x86_64 | 3.5.1 | MacOS X X86_64 | 2025/3.9.2 |
-| matplotlib-3.5.1-cp39-cp39-macosx_11_0_arm64 | 3.5.1 | MacOS X M1 | 2025/3.9.2 |
-| shapely-2.0.4-cp39-cp39-win_amd64.whl | 2.0.4 | Windows | 2025/3.9.2 |
-| shapely-2.0.4-cp39-cp39-macosx_10_9_universal2.whl | 2.0.4 | MacOS X M1 | 2025/3.9.2 |
+| numpy-2.5.1-cp314-cp314-win_amd64.whl | 2.5.1 | Windows | 2026/3.14.5 |
+| numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl | 2.5.1 | MacOS X X86_64 | 2026/3.14.5 |
+| numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl | 2.5.1 | MacOS X M1 | 2026/3.14.5 |
+| scipy-1.18.0-cp314-cp314-win_amd64.whl | 1.18.0 | Windows | 2026/3.14.5 |
+| scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl | 1.18.0 | MacOS X X86_64 | 2026/3.14.5 |
+| scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl | 1.18.0 | MacOS X M1 | 2026/3.14.5 |
+| geopy-2.5.0-py3-none-any.whl | 2.5.0 | Windows | 2026/3.14.5 |
+| geopy-2.5.0-py3-none-any.whl | 2.5.0 | MacOS X X86_64 | 2026/3.14.5 |
+| geopy-2.5.0-py3-none-any.whl | 2.5.0 | MacOS X M1 | 2026/3.14.5 |
+| pillow-12.3.0-cp314-cp314-win_amd64.whl | 12.3.0 | Windows | 2026/3.14.5 |
+| pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl | 12.3.0 | MacOS X X86_64 | 2026/3.14.5 |
+| pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl | 12.3.0 | MacOS X M1 | 2026/3.14.5 |
+| plotly-6.9.0-py3-none-any.whl | 6.9.0 | Windows | 2026/3.14.5 |
+| plotly-6.9.0-py3-none-any.whl | 6.9.0 | MacOS X X86_64 | 2026/3.14.5 |
+| plotly-6.9.0-py3-none-any.whl | 6.9.0 | MacOS X M1 | 2026/3.14.5 |
+| pandas-3.0.3-cp314-cp314-win_amd64.whl | 3.0.3 | Windows | 2026/3.14.5 |
+| pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl | 3.0.3 | MacOS X X86_64 | 2026/3.14.5 |
+| pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl | 3.0.3 | MacOS X M1 | 2026/3.14.5 |
+| matplotlib-3.11.1-cp314-cp314-win_amd64.whl | 3.11.1 | Windows | 2026/3.14.5 |
+| matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl | 3.11.1 | MacOS X X86_64 | 2026/3.14.5 |
+| matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl | 3.11.1 | MacOS X M1 | 2026/3.14.5 |
+| shapely-2.1.2-cp314-cp314-win_amd64.whl | 2.1.2 | Windows | 2026/3.14.5 |
+| shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl | 2.1.2 | MacOS X M1 | 2026/3.14.5 |
 
 ## Description of the Marionette Node changes
 ![NewSyntax](files/NewSyntax.png)

--- a/Marionette/pages/Python Package Catalog.md
+++ b/Marionette/pages/Python Package Catalog.md
@@ -1,3 +1,5 @@
+
+Vectorworks 2027
 | Package | Package Version | Package OS | VW Version Python Version |
 |---------|-----------------|------------|---------------------------|
 | numpy-2.5.1-cp314-cp314-win_amd64.whl | 2.5.1 | Windows | 2026/3.14.5 |
@@ -24,6 +26,9 @@
 | shapely-2.1.2-cp314-cp314-win_amd64.whl | 2.1.2 | Windows | 2026/3.14.5 |
 | shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl | 2.1.2 | MacOS X M1 | 2026/3.14.5 |
 
+Vectorworks 2026
+| Package | Package Version | Package OS | VW Version Python Version |
+|---------|-----------------|------------|---------------------------|
 | numpy-1.22.1-cp39-cp39-win_amd64 | 1.22.1 | Windows | 2025/3.9.2 |
 | numpy-1.22.1-cp39-cp39-macosx_10_9_x86_64 | 1.22.1 | MacOS X X86_64 | 2025/3.9.2 |
 | numpy-1.22.1-cp39-cp39-macosx_11_0_arm64 | 1.22.1 | MacOS X M1 | 2025/3.9.2 |

--- a/Marionette/pages/Python Package Catalog.md
+++ b/Marionette/pages/Python Package Catalog.md
@@ -1,5 +1,5 @@
 
-Vectorworks 2027
+## Vectorworks 2027
 | Package | Package Version | Package OS | VW Version Python Version |
 |---------|-----------------|------------|---------------------------|
 | numpy-2.5.1-cp314-cp314-win_amd64.whl | 2.5.1 | Windows | 2026/3.14.5 |
@@ -26,7 +26,7 @@ Vectorworks 2027
 | shapely-2.1.2-cp314-cp314-win_amd64.whl | 2.1.2 | Windows | 2026/3.14.5 |
 | shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl | 2.1.2 | MacOS X M1 | 2026/3.14.5 |
 
-Vectorworks 2026
+## Vectorworks 2026
 | Package | Package Version | Package OS | VW Version Python Version |
 |---------|-----------------|------------|---------------------------|
 | numpy-1.22.1-cp39-cp39-win_amd64 | 1.22.1 | Windows | 2025/3.9.2 |


### PR DESCRIPTION
Update Python package catalog with newer versions compatible with Python 3.14.5 (VW 2027). This includes updated versions of numpy, scipy, pandas, matplotlib, plotly, pillow, geopy, and shapely with corresponding macOS and Windows wheel files.